### PR TITLE
fix syntax error - 'let' and default value assignment

### DIFF
--- a/lib/analyser.js
+++ b/lib/analyser.js
@@ -4,7 +4,7 @@ module.exports = {
   erase
 }
 
-let tree = {}
+var tree = {}
 function compute(entry, modules, file) {
   const moduleName = sanitizeModuleName(entry)
   initNode(moduleName)

--- a/lib/build_data.js
+++ b/lib/build_data.js
@@ -6,7 +6,7 @@ module.exports = {
   results
 }
 
-function analyse(fileName, file, whitelist = []) {
+function analyse(fileName, file, whitelist) {
   if(fileParser.isJSX(file)) {
     const modules = fileParser.parse(file, whitelist)
     analyser.compute(fileName, modules, file)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,7 +20,7 @@ glob(path.join(config.root, '**/*.js'), (err, files) => {
     return
   }
 
-  let queue = []
+  var queue = []
   files.forEach(path => {
    const op =  fs.readFileAsync(path, 'utf-8').then((file) => {
       buildData.analyse(path.replace(config.root, ''), file, config.whitelist)

--- a/lib/file_parser.js
+++ b/lib/file_parser.js
@@ -11,7 +11,7 @@ function isJSX(file) {
   return module && module.indexOf('react') > -1
 }
 
-function parse(file, whitelist = []) {
+function parse(file, whitelist) {
   return file.split('\n').reduce((modules, line) => {
     const module = extractModule(line)
 
@@ -23,7 +23,7 @@ function parse(file, whitelist = []) {
   }, [])
 }
 
-function isAllowed(module = '', whitelist = []) {
+function isAllowed(module, whitelist) {
   if(whitelist.length === 0) {
     return true
   }
@@ -38,6 +38,3 @@ function extractModule(modulePath) {
 
   return result.pop()
 }
-
-
-


### PR DESCRIPTION
I had so many syntax error, when I ran `react-analytic` command. Some type is related in ES6 keyword `let` and another is `unexpected token =`

`let`
- react-analytic/lib/cli.js:23
- react-analytic/lib/analyser.js:7
- react-analytic/lib/analyser.js:29

```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

`unexpected token =`
- react-analytic/lib/build_data.js:9
- react-analytic/lib/file_parser.js:14
- react-analytic/lib/file_parser.js:26
- react-analytic/lib/file_parser.js:26

```
SyntaxError: Unexpected token =
```

After fix these syntax error, I can see the result at my browser.
![2016-07-15 12 14 17](https://cloud.githubusercontent.com/assets/8944017/16846329/f24a135c-4a26-11e6-9706-b8fc2ac56e24.png)
